### PR TITLE
Remove obsolete meta tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,6 @@
 <html class="no-js" lang="">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This PR removes the meta tag for `x-ua-compatible`.

**Why?**

This tag was introduced with IE8 for 'Compatibility View' - a mechanism for the browser to choose a rendering mode.

With MS [discontinuing support](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support) for older browsers, perhaps this tag is no longer necessary?
